### PR TITLE
Fix file name in error message for input file.

### DIFF
--- a/mysendevent.c
+++ b/mysendevent.c
@@ -83,7 +83,7 @@ int main(int argc, char *argv[])
 
     FILE * fd_in = fopen(argv[2], "r");
     if (fd_in == NULL) {
-        fprintf(stderr, "could not open input file: %s\n", argv[1]);
+        fprintf(stderr, "could not open input file: %s\n", argv[2]);
         return 1;
     }
 


### PR DESCRIPTION
In the previous revision the error message on line 86 prints the input_device argument rather than the input_events argument as intended.