### PR TITLE
Update mysendevent.c

### DIFF
--- a/mysendevent.c
+++ b/mysendevent.c
@@ -113,6 +113,11 @@ int main(int argc, char *argv[])
 
         // In order to playback the same gestures the code sleeps accordingly to the timestamps from the inputed recording
         sleep_time = (unsigned int) ((timestamp_now - timestamp_previous) * MICROSEC);
+        
+        if(timestamp_previous != 0.0){
+            usleep(sleep_time);        
+        }
+        
         // we don't care about the value of a single event's timestamp but the difference between two sequential events
         usleep(sleep_time); // sleep_time is in MICROSECONDS
         timestamp_previous = timestamp_now;


### PR DESCRIPTION
When the loop starts the and calculates `sleep_time`, the value that it outputs is wrong. This is because `timestamp_previous` is not a timestamp but 0.0 as it was defined as the starting value.