### PR TITLE
Revisions and enhancements in scripts

### DIFF
--- a/find_touchscreen_name.sh
+++ b/find_touchscreen_name.sh
@@ -1,14 +1,11 @@
 #!/bin/bash
 
 # this script reads the info of each of the input devices
-while read -r line; do
-  OUTPUT=`adb shell getevent -lp "$line"`
-  # The touchscreen device contains the keyword ABS_MT_TOUCH in its info
-  if [[ "$OUTPUT" = *"ABS_MT_TOUCH"* ]]; then
-    echo "Touchscreen device found! -> $line"
-    exit
-  fi
-done < <(adb shell getevent -lp | egrep -o "(/dev/input/event\S+)") # this will find all the input devices
-# (/dev/input/event\S+) searches for a string that starts with "/dev/input/event" and is followed by any non-whitespace characters
-
+#devs=`adb shell getevent -lp 2>/dev/null | egrep -o "(/dev/input/event\S+)"`
+for line in `adb shell getevent -lp 2>/dev/null | egrep -o "(/dev/input/event\S+)"`; do
+  echo $line
+  output=`adb shell getevent -lp $line`
+  # The touchscreen device contains the keyword ABS_MT in its info
+  [[ "$output" == *"ABS_MT"* ]] && { echo "Touchscreen device found! -> $line"; exit; }
+done
 echo "Touchscreen not found!"

--- a/replay_touch_events.sh
+++ b/replay_touch_events.sh
@@ -7,14 +7,11 @@ echo "$TOUCH_DEVICE"
 
 # Check if the file `mysendevent` exists in the phone
 
-MYSENDEVENT=`adb shell ls /data/local/tmp/mysendevent`
+MYSENDEVENT=`adb shell ls /data/local/tmp/mysendevent 2>&1`
+echo ---"$MYSENDEVENT"---
+[[ "$MYSENDEVENT" == *"No such file or directory"* ]] && adb push mysendevent /data/local/tmp/
 
-if [[ "$MYSENDEVENT" = *"No such file or directory"* ]]
-then
-    `adb push mysendevent /data/local/tmp/`
-fi
-
-`adb push recorded_touch_events.txt /sdcard/`
+adb push recorded_touch_events.txt /sdcard/
 
 # Replay the recorded events
-`adb shell /data/local/tmp/mysendevent "${TOUCH_DEVICE#*-> }" /sdcard/recorded_touch_events.txt`
+adb shell /data/local/tmp/mysendevent "${TOUCH_DEVICE#*-> }" /sdcard/recorded_touch_events.txt


### PR DESCRIPTION
find_touchscreen_name.sh -> stderr forwarded to /dev/null to avoid some mistakes. Script simplified.
replay_touch_events.sh -> stderr forwarded to stdout since 'No such file or directory' is stderr message. Script simplified.