### PR TITLE
Use 'exec-out' instead of 'shell'. Fixes last touch not being fully recorded

### DIFF
--- a/record_touch_events.sh
+++ b/record_touch_events.sh
@@ -11,5 +11,7 @@ then
     # Device found! Start recording
     echo "Recording will start as soon as you put your finger in the touchscreen."
     echo "Press ctrl+c to stop recording..."
-    `adb shell getevent -t "${TOUCH_DEVICE#*-> }" > recorded_touch_events.txt`
+    
+    #exec-out is shell without buffering, fixing missing last touch data event
+    `adb exec-out getevent -t "${TOUCH_DEVICE#*-> }" > recorded_touch_events.txt` 
 fi


### PR DESCRIPTION
A simple fix to make recording working as it should: capturing all data. When using `shell` there is some buffering at play which causes the last touch events not being fully recorded resulting in weird hanging touch at the end of playback. `exec-out` is `shell` without buffering.